### PR TITLE
chore: Rename package from `ipld-resolver` to `ipld`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ipld-resolver",
+  "name": "ipld",
   "version": "0.14.1",
   "description": "IPLD Resolver Implementation in JavaScript",
   "main": "src/index.js",


### PR DESCRIPTION
BREAKING CHANGE: All packages that depend on `ipld-resolver`
need to change their dependency.

Within your package that depends on `ipld-resolver` do:

    npm uninstall ipld-resolver
    npm intall ipld

Then search for all imports of `ipld-resolver` and change from

    const IPLDResolver = require('ipld-resolver')

to

    const Ipld = require('ipld')

Closes #116.