### PR TITLE
fix: handle required options for IPLDResolver.put

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,10 @@ class IPLDResolver {
 
   put (node, options, callback) {
     if (typeof options === 'function') {
-      return setImmediate(() => callback(new Error('no options were passed')))
+      callback = options
+      return setImmediate(() => callback(
+        new Error('IPLDResolver.put requires options')
+      ))
     }
     callback = callback || noop
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -67,6 +67,16 @@ module.exports = (repo) => {
       })
     })
 
+    it('put - errors if no options', (done) => {
+      const bs = new BlockService(repo)
+      const r = new IPLDResolver(bs)
+      r.put(null, (err, result) => {
+        expect(err).to.exist()
+        expect(err.message).to.eql('IPLDResolver.put requires options')
+        done()
+      })
+    })
+
     it('_put - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
       const r = new IPLDResolver(bs)


### PR DESCRIPTION
I also made the message more informative because we lose the stack trace with `setImmediate`.