### PR TITLE
Refactor ipld to use pull streams for get

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,9 +131,9 @@ class IPLDResolver {
     pull(this.getPullStream(cid, path, options),
       pull.reduce((arr, item) => {
         if (options.onlyNode) {
+          // reducing to the last item
           arr[0] = item
         } else {
-          // reducing to the last item
           arr.push(item)
         }
         return arr

--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,7 @@ class IPLDResolver {
           const endReached = !path || path === '' || path === '/'
           const isTerminal = value && !value['/']
 
-          if ((endReached && isTerminal) || options.localResolve) {
+          if ((endReached && isTerminal) || (options && options.localResolve)) {
             stop = true
             return cb(null, { value, remainderPath: path })
           }

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ class IPLDResolver {
 
     let stop = false
     if (path === '' || !path) {
-      return function read (abort, cb) {
+      return function read (_abort, cb) {
         if (stop) return cb(stop)
         this._get(cid, (err, node) => {
           if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -130,11 +130,11 @@ class IPLDResolver {
 
     pull(this.getPullStream(cid, path, options),
       pull.reduce((arr, item) => {
-        if (!options.onlyNode) {
-          arr.push(item)
-        } else {
-          // replace existing entry
+        if (options.onlyNode) {
           arr[0] = item
+        } else {
+          // reducing to the last item
+          arr.push(item)
         }
         return arr
       }, [], callback)

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -61,11 +61,11 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
   })
 
   it('resolve through different formats', (done) => {
-    resolver.get(cidCbor, 'pb/Data', (err, result) => {
+    resolver.get(cidCbor, 'pb/Data', (err, results) => {
       expect(err).to.not.exist()
-      expect(result.length).to.eq(2)
-      dagCBOR.util.cid(result[0].value['/'], (cid) => expect(cid).to.eql(cidPb))
-      expect(result[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
+      expect(results.length).to.eq(2)
+      expect(results[0].value['/']).to.eql(cidPb.multihash)
+      expect(results[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
       done()
     })
   })
@@ -75,17 +75,17 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
       pull.collect((err, results) => {
         expect(err).to.not.exist()
         expect(results.length).to.eq(2)
-        dagCBOR.util.cid(results[0].value['/'], (cid) => expect(cid).to.eql(cidPb))
+        expect(results[0].value['/']).to.eql(cidPb.multihash)
         expect(results[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
         done()
       }))
   })
 
   it('resolve honors onlyNode option', (done) => {
-    resolver.get(cidCbor, 'pb/Data', { onlyNode: true }, (err, result) => {
+    resolver.get(cidCbor, 'pb/Data', { onlyNode: true }, (err, results) => {
       expect(err).to.not.exist()
-      expect(result.length).to.eq(1)
-      expect(result[0].value).to.eql(Buffer.from('I am inside a Protobuf'))
+      expect(results.length).to.eq(1)
+      expect(results[0].value).to.eql(Buffer.from('I am inside a Protobuf'))
       done()
     })
   })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -15,6 +15,7 @@ const dagPB = require('ipld-dag-pb')
 const dagCBOR = require('ipld-dag-cbor')
 const each = require('async/each')
 const waterfall = require('async/waterfall')
+const pull = require('pull-stream')
 
 const IPLDResolver = require('../src')
 
@@ -69,6 +70,17 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
     })
   })
 
+  it('resolver.getPullStream through different formats', (done) => {
+    pull(resolver.getPullStream(cidCbor, 'pb/Data'),
+      pull.collect((err, results) => {
+        expect(err).to.not.exist()
+        expect(results.length).to.eq(2)
+        dagCBOR.util.cid(results[0].value['/'], (cid) => expect(cid).to.eql(cidPb))
+        expect(results[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
+        done()
+      }))
+  })
+
   it('resolve honors onlyNode option', (done) => {
     resolver.get(cidCbor, 'pb/Data', { onlyNode: true }, (err, result) => {
       expect(err).to.not.exist()
@@ -77,5 +89,4 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
       done()
     })
   })
-
 })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -62,7 +62,8 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
   it('resolve through different formats', (done) => {
     resolver.get(cidCbor, 'pb/Data', (err, result) => {
       expect(err).to.not.exist()
-      expect(result.value).to.eql(Buffer.from('I am inside a Protobuf'))
+      expect(result.length).to.eq(2)
+      expect(result[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
       done()
     })
   })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -69,4 +69,13 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
     })
   })
 
+  it('resolve honors onlyNode option', (done) => {
+    resolver.get(cidCbor, 'pb/Data', { onlyNode: true }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result.length).to.eq(1)
+      expect(result[0].value).to.eql(Buffer.from('I am inside a Protobuf'))
+      done()
+    })
+  })
+
 })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -63,8 +63,10 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
     resolver.get(cidCbor, 'pb/Data', (err, result) => {
       expect(err).to.not.exist()
       expect(result.length).to.eq(2)
+      dagCBOR.util.cid(result[0].value['/'], (cid) => expect(cid).to.eql(cidPb))
       expect(result[1].value).to.eql(Buffer.from('I am inside a Protobuf'))
       done()
     })
   })
+
 })

--- a/test/ipld-bitcoin.js
+++ b/test/ipld-bitcoin.js
@@ -109,7 +109,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            expect(node1.version).to.eql(result.value.version)
+            expect(node1.version).to.eql(result[0].value.version)
             done()
           })
         })
@@ -125,7 +125,7 @@ module.exports = (repo) => {
         resolver.get(cid1, '/', (err, result) => {
           expect(err).to.not.exist()
 
-          ipldBitcoin.util.cid(result.value, (err, cid) => {
+          ipldBitcoin.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -136,7 +136,8 @@ module.exports = (repo) => {
       it('value within 1st node scope', (done) => {
         resolver.get(cid1, 'version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(1)
+          expect(result[0].value).to.eql(1)
           done()
         })
       })
@@ -144,7 +145,8 @@ module.exports = (repo) => {
       it('value within nested scope (1 level)', (done) => {
         resolver.get(cid2, 'parent/version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql(1)
           done()
         })
       })
@@ -152,7 +154,8 @@ module.exports = (repo) => {
       it('value within nested scope (2 levels)', (done) => {
         resolver.get(cid3, 'parent/parent/version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(3)
+          expect(result[2].value).to.eql(1)
           done()
         })
       })
@@ -162,7 +165,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            expect(result.value.version).to.eql(1)
+            expect(result[0].value.version).to.eql(1)
             remove()
           })
         })

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -115,11 +115,11 @@ module.exports = (repo) => {
       })
 
       it('resolver.get just CID', (done) => {
-        resolver.get(cid1, (err, results) => {
-          expect(results.length).to.eq(1)
+        resolver.get(cid1, (err, result) => {
+          expect(result.length).to.eq(1)
           expect(err).to.not.exist()
 
-          dagCBOR.util.cid(results[0].value, (err, cid) => {
+          dagCBOR.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -128,11 +128,11 @@ module.exports = (repo) => {
       })
 
       it('resolver.get root path', (done) => {
-        resolver.get(cid1, '/', (err, results) => {
-          expect(results.length).to.eq(1)
+        resolver.get(cid1, '/', (err, result) => {
+          expect(result.length).to.eq(1)
           expect(err).to.not.exist()
 
-          dagCBOR.util.cid(results[0].value, (err, cid) => {
+          dagCBOR.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -114,11 +114,26 @@ module.exports = (repo) => {
         }, done)
       })
 
+      it('resolver.getPullStream just CID', (done) => {
+        pull(resolver.getPullStream(cid1, null),
+          pull.collect((err, results) => {
+            expect(err).to.not.exist()
+            expect(results.length).to.eq(1)
+
+            dagCBOR.util.cid(results[0].value, (err, cid) => {
+              expect(err).to.not.exist()
+              expect(cid).to.eql(cid1)
+            })
+          }))
+        done()
+      })
+
       it('resolver.get just CID', (done) => {
-        resolver.get(cid1, (err, result) => {
+        resolver.get(cid1, (err, results) => {
+          expect(results.length).to.eq(1)
           expect(err).to.not.exist()
 
-          dagCBOR.util.cid(result.value, (err, cid) => {
+          dagCBOR.util.cid(results[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -127,10 +142,11 @@ module.exports = (repo) => {
       })
 
       it('resolver.get root path', (done) => {
-        resolver.get(cid1, '/', (err, result) => {
+        resolver.get(cid1, '/', (err, results) => {
+          expect(results.length).to.eq(1)
           expect(err).to.not.exist()
 
-          dagCBOR.util.cid(result.value, (err, cid) => {
+          dagCBOR.util.cid(results[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -141,8 +157,9 @@ module.exports = (repo) => {
       it('resolver.get relative path `.` (same as get /)', (done) => {
         resolver.get(cid1, '.', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          dagCBOR.util.cid(result.value, (err, cid) => {
+          dagCBOR.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -153,8 +170,9 @@ module.exports = (repo) => {
       it('resolver.get relative path `./` (same as get /)', (done) => {
         resolver.get(cid1, './', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          dagCBOR.util.cid(result.value, (err, cid) => {
+          dagCBOR.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -165,7 +183,8 @@ module.exports = (repo) => {
       it('resolver.get relative path `./one/someData` (same as get one/someData)', (done) => {
         resolver.get(cid2, './one/someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('I am 1')
           done()
         })
       })
@@ -173,7 +192,8 @@ module.exports = (repo) => {
       it('resolver.get relative path `one/./someData` (same as get one/someData)', (done) => {
         resolver.get(cid2, 'one/./someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('I am 1')
           done()
         })
       })
@@ -181,7 +201,8 @@ module.exports = (repo) => {
       it('resolver.get double slash at the beginning `//one/someData` (same as get one/someData)', (done) => {
         resolver.get(cid2, '//one/someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('I am 1')
           done()
         })
       })
@@ -189,7 +210,8 @@ module.exports = (repo) => {
       it('resolver.get double slash in the middle `one//someData` (same as get one/someData)', (done) => {
         resolver.get(cid2, 'one//someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('I am 1')
           done()
         })
       })
@@ -197,7 +219,8 @@ module.exports = (repo) => {
       it('resolver.get value within 1st node scope', (done) => {
         resolver.get(cid1, 'someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(1)
+          expect(result[0].value).to.eql('I am 1')
           done()
         })
       })
@@ -205,7 +228,8 @@ module.exports = (repo) => {
       it('resolver.get value within nested scope (0 level)', (done) => {
         resolver.get(cid2, 'one', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql({
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql({
             someData: 'I am 1'
           })
           done()
@@ -215,7 +239,8 @@ module.exports = (repo) => {
       it('resolver.get value within nested scope (1 level)', (done) => {
         resolver.get(cid2, 'one/someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('I am 1')
           done()
         })
       })
@@ -223,8 +248,9 @@ module.exports = (repo) => {
       it('resolver.get value within nested scope (2 levels)', (done) => {
         resolver.get(cid3, 'two/one/someData', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('I am 1')
-          expect(result.remainderPath).to.eql('')
+          expect(result.length).to.eq(3)
+          expect(result[2].value).to.eql('I am 1')
+          expect(result[2].remainderPath).to.eql('')
 
           done()
         })
@@ -306,7 +332,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            expect(node1).to.eql(result.value)
+            expect(node1).to.eql(result[0].value)
             remove()
           })
         })

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -114,20 +114,6 @@ module.exports = (repo) => {
         }, done)
       })
 
-      it('resolver.getPullStream just CID', (done) => {
-        pull(resolver.getPullStream(cid1, null),
-          pull.collect((err, results) => {
-            expect(err).to.not.exist()
-            expect(results.length).to.eq(1)
-
-            dagCBOR.util.cid(results[0].value, (err, cid) => {
-              expect(err).to.not.exist()
-              expect(cid).to.eql(cid1)
-            })
-          }))
-        done()
-      })
-
       it('resolver.get just CID', (done) => {
         resolver.get(cid1, (err, results) => {
           expect(results.length).to.eq(1)

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -178,8 +178,9 @@ module.exports = (repo) => {
       it('resolver.get root path', (done) => {
         resolver.get(cid1, '/', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          dagPB.util.cid(result.value, (err, cid) => {
+          dagPB.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -190,7 +191,8 @@ module.exports = (repo) => {
       it('resolver.get value within 1st node scope', (done) => {
         resolver.get(cid1, 'Data', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(Buffer.from('I am 1'))
+          expect(result.length).to.eq(1)
+          expect(result[0].value).to.eql(Buffer.from('I am 1'))
           done()
         })
       })
@@ -198,7 +200,8 @@ module.exports = (repo) => {
       it('resolver.get value within nested scope (1 level)', (done) => {
         resolver.get(cid2, 'Links/0/Hash/Data', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(Buffer.from('I am 1'))
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql(Buffer.from('I am 1'))
           done()
         })
       })
@@ -206,7 +209,8 @@ module.exports = (repo) => {
       it('resolver.get value within nested scope (2 levels)', (done) => {
         resolver.get(cid3, 'Links/1/Hash/Links/0/Hash/Data', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(Buffer.from('I am 1'))
+          expect(result.length).to.eq(3)
+          expect(result[2].value).to.eql(Buffer.from('I am 1'))
           done()
         })
       })
@@ -214,8 +218,9 @@ module.exports = (repo) => {
       it('resolver.get with option localResolve: true', (done) => {
         resolver.get(cid3, 'Links/1/Hash/Links/0/Hash/Data', { localResolve: true }, (err, result) => {
           expect(err).to.not.exist()
-          expect(result.remainderPath).to.equal('Links/0/Hash/Data')
-          expect(result.value).to.eql({
+          expect(result.length).to.eq(1)
+          expect(result[0].remainderPath).to.equal('Links/0/Hash/Data')
+          expect(result[0].value).to.eql({
             '/': 'QmS149H7EbyMuZ2wtEF1sAd7gPwjj4rKAorweAjKMkxr8D'
           })
           done()

--- a/test/ipld-eth-block.js
+++ b/test/ipld-eth-block.js
@@ -96,9 +96,10 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
+            expect(result.length).to.eq(1)
             expect(node1.number.toString('hex')).to.eql('01')
-            expect(node1.raw).to.eql(result.value.raw)
-            expect(node1.hash()).to.eql(result.value.hash())
+            expect(node1.raw).to.eql(result[0].value.raw)
+            expect(node1.hash()).to.eql(result[0].value.hash())
             done()
           })
         })
@@ -113,8 +114,9 @@ module.exports = (repo) => {
       it('root path (same as get)', (done) => {
         resolver.get(cid1, '/', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          ipldEthBlock.util.cid(result.value, (err, cid) => {
+          ipldEthBlock.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -125,7 +127,8 @@ module.exports = (repo) => {
       it('value within 1st node scope', (done) => {
         resolver.get(cid1, 'number', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value.toString('hex')).to.eql('01')
+          expect(result.length).to.eq(1)
+          expect(result[0].value.toString('hex')).to.eql('01')
           done()
         })
       })
@@ -133,7 +136,8 @@ module.exports = (repo) => {
       it('value within nested scope (1 level)', (done) => {
         resolver.get(cid2, 'parent/number', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value.toString('hex')).to.eql('01')
+          expect(result.length).to.eq(2)
+          expect(result[1].value.toString('hex')).to.eql('01')
           done()
         })
       })
@@ -141,7 +145,9 @@ module.exports = (repo) => {
       it('value within nested scope (2 levels)', (done) => {
         resolver.get(cid3, 'parent/parent/number', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value.toString('hex')).to.eql('01')
+          expect(err).to.not.exist()
+          expect(result.length).to.eq(3)
+          expect(result[2].value.toString('hex')).to.eql('01')
           done()
         })
       })
@@ -151,7 +157,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            const node = result.value
+            const node = result[0].value
             expect(node1.raw).to.eql(node.raw)
             expect(node1.hash()).to.eql(node.hash())
             remove()

--- a/test/ipld-eth.js
+++ b/test/ipld-eth.js
@@ -87,19 +87,19 @@ module.exports = (repo) => {
 
     describe('resolver.get', () => {
       it('block-to-block', (done) => {
-        resolver.get(ethObjs.child.cid, '/parent', (err, result) => {
+        resolver.get(ethObjs.child.cid, '/parent', {onlyNode: true}, (err, result) => {
           expect(err).to.not.exist()
-          expect(result.remainderPath).to.equal('')
-          expect(result.value.number.toString('hex')).to.equal('302516')
+          expect(result[0].remainderPath).to.equal('')
+          expect(result[0].value.number.toString('hex')).to.equal('302516')
           done()
         })
       })
 
       it('block-to-account resolve', (done) => {
-        resolver.get(ethObjs.child.cid, '/parent/state/0/0/0/0/1/7/2/7/8/a/1/e/6/e/9/6/3/5/e/1/a/3/f/1/1/e/b/0/2/2/d/a/1/f/5/7/e/a/0/0/4/d/8/5/2/d/9/d/1/9/4/2/d/4/3/6/0/8/5/4/0/4/7/1/nonce', (err, result) => {
+        resolver.get(ethObjs.child.cid, '/parent/state/0/0/0/0/1/7/2/7/8/a/1/e/6/e/9/6/3/5/e/1/a/3/f/1/1/e/b/0/2/2/d/a/1/f/5/7/e/a/0/0/4/d/8/5/2/d/9/d/1/9/4/2/d/4/3/6/0/8/5/4/0/4/7/1/nonce', {onlyNode: true}, (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value.toString('hex'), '03')
-          expect(result.remainderPath).to.equal('')
+          expect(result[0].value.toString('hex'), '03')
+          expect(result[0].remainderPath).to.equal('')
           done()
         })
       })

--- a/test/ipld-git.js
+++ b/test/ipld-git.js
@@ -163,7 +163,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(blobCid, (err, result) => {
             expect(err).to.not.exist()
-            expect(blobNode.toString('hex')).to.eql(result.value.toString('hex'))
+            expect(blobNode.toString('hex')).to.eql(result[0].value.toString('hex'))
             done()
           })
         })
@@ -178,8 +178,9 @@ module.exports = (repo) => {
       it('resolver.get root path', (done) => {
         resolver.get(blobCid, '/', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          ipldGit.util.cid(result.value, (err, cid) => {
+          ipldGit.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(blobCid)
             done()
@@ -190,7 +191,8 @@ module.exports = (repo) => {
       it('value within 1st node scope', (done) => {
         resolver.get(commitCid, 'message', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('Initial commit\n')
+          expect(result.length).to.eq(1)
+          expect(result[0].value).to.eql('Initial commit\n')
           done()
         })
       })
@@ -198,7 +200,8 @@ module.exports = (repo) => {
       it('value within nested node scope (commit/tree)', (done) => {
         resolver.get(commitCid, 'tree/somefile/mode', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql('100644')
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql('100644')
           done()
         })
       })
@@ -206,7 +209,8 @@ module.exports = (repo) => {
       it('value within nested node scope (commit/tree/blob)', (done) => {
         resolver.get(commitCid, 'tree/somefile/hash', (err, result) => {
           expect(err).to.not.exist()
-          expect(blobNode.toString('hex')).to.eql(result.value.toString('hex'))
+          expect(result.length).to.eq(3)
+          expect(blobNode.toString('hex')).to.eql(result[2].value.toString('hex'))
           done()
         })
       })
@@ -214,7 +218,8 @@ module.exports = (repo) => {
       it('value within nested node scope (commit/commit/tree/blob)', (done) => {
         resolver.get(commit2Cid, 'parents/0/tree/somefile/hash', (err, result) => {
           expect(err).to.not.exist()
-          expect(blobNode.toString('hex')).to.eql(result.value.toString('hex'))
+          expect(result.length).to.eq(4)
+          expect(blobNode.toString('hex')).to.eql(result[3].value.toString('hex'))
           done()
         })
       })
@@ -222,7 +227,8 @@ module.exports = (repo) => {
       it('value within nested node scope (tag/commit/commit/tree/blob)', (done) => {
         resolver.get(tagCid, 'object/parents/0/tree/somefile/hash', (err, result) => {
           expect(err).to.not.exist()
-          expect(blobNode.toString('hex')).to.eql(result.value.toString('hex'))
+          expect(result.length).to.eq(5)
+          expect(blobNode.toString('hex')).to.eql(result[4].value.toString('hex'))
           done()
         })
       })
@@ -232,7 +238,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(blobCid, (err, result) => {
             expect(err).to.not.exist()
-            const node = result.value
+            const node = result[0].value
             expect(blobNode.toString('hex')).to.eql(node.toString('hex'))
             remove()
           })

--- a/test/ipld-zcash.js
+++ b/test/ipld-zcash.js
@@ -114,7 +114,8 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            expect(node1.header.version).to.eql(result.value.header.version)
+            expect(result.length).to.eq(1)
+            expect(node1.header.version).to.eql(result[0].value.header.version)
             done()
           })
         })
@@ -129,8 +130,9 @@ module.exports = (repo) => {
       it('root path (same as get)', (done) => {
         resolver.get(cid1, '/', (err, result) => {
           expect(err).to.not.exist()
+          expect(result.length).to.eq(1)
 
-          ipldZcash.util.cid(result.value, (err, cid) => {
+          ipldZcash.util.cid(result[0].value, (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.eql(cid1)
             done()
@@ -141,7 +143,8 @@ module.exports = (repo) => {
       it('value within 1st node scope', (done) => {
         resolver.get(cid1, 'version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(1)
+          expect(result[0].value).to.eql(1)
           done()
         })
       })
@@ -149,7 +152,8 @@ module.exports = (repo) => {
       it('value within nested scope (1 level)', (done) => {
         resolver.get(cid2, 'parent/version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(2)
+          expect(result[1].value).to.eql(1)
           done()
         })
       })
@@ -157,7 +161,8 @@ module.exports = (repo) => {
       it('value within nested scope (2 levels)', (done) => {
         resolver.get(cid3, 'parent/parent/version', (err, result) => {
           expect(err).to.not.exist()
-          expect(result.value).to.eql(1)
+          expect(result.length).to.eq(3)
+          expect(result[2].value).to.eql(1)
           done()
         })
       })
@@ -167,7 +172,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           resolver.get(cid1, (err, result) => {
             expect(err).to.not.exist()
-            expect(result.value.header.version).to.eql(1)
+            expect(result[0].value.header.version).to.eql(1)
             remove()
           })
         })


### PR DESCRIPTION
This a PR to refactor ipld resolver to use pull streams #101 , as well as change the default behavior from returning a single value in a callback to returning an array. In addition to this the changes will expose getPullStream which should allow people to read the stream and process each node along the path. 

In this PR, I didn't add explicit tests for proper path resolution (i.e. the collected along the path are correct), wanted to get a little more feedback first. Also note this will be a breaking change. 

@vmx PTAL when you get a chance, and let me know if the interface should change or any thing you'd like to see implemented differently, also if you have any pointers to other projects that will need to be updated to support this change, that would be great!