### PR TITLE
Fix "resolver exists" error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class IPLDResolver {
     // Adds support for an IPLD format
     this.support.add = (multicodec, resolver, util) => {
       if (this.resolvers[multicodec]) {
-        throw new Error(multicodec + 'already supported')
+        throw new Error('Resolver already exists for codec "' + multicodec + '"')
       }
 
       this.resolvers[multicodec] = {


### PR DESCRIPTION
When bundling a web app that depends on js-ipfs with [parcel](https://parceljs.org/) I get this error msg.

```js
es6.promise.js:110 Unhandled promise rejection Error: dag-cboralready supported
    at Object.IPLDResolver.support.add (index.js:48)
    at new IPLDResolver (index.js:72)
    at new IPFS (index.js:72)
```

This PR just fixes the formatting of the error message (**dag-cboralready supported**) and brings it more in line with the tone of the other error messages in the file.

I'm going to dig around and raise a separate issue for the cause of the error.