### PR TITLE
Fix/node10

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,1 +1,2 @@
-javascript()
+javascript(['nodejs_versions': ['8.11.1','9.2.0','10.0.0']])
+

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "interface-datastore": "~0.4.2",
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",
-    "ipfs-repo": "github:ipfs/js-ipfs-repo#fix/node10",
+    "ipfs-repo": "~0.22.0",
     "ipld-bitcoin": "~0.1.5",
     "ipld-dag-cbor": "~0.12.0",
     "ipld-dag-pb": "~0.14.4",


### PR DESCRIPTION
This PR updates the version of ipfs-repo. This is to address an issue with js-ipfs failing to run on node 10 due to leveldown versions.

Depends on https://github.com/ipfs/js-ipfs-repo/pull/168
Connects to https://github.com/ipfs/js-ipfs/issues/1347