### PR TITLE
refactor: remove eth-hash-to-cid module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "bitcoinjs-lib": "^4.0.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "eth-hash-to-cid": "~0.1.1",
     "ethereumjs-block": "^2.1.0",
     "ipld-bitcoin": "~0.1.8",
     "ipld-ethereum": "^2.0.1",

--- a/test/ipld-eth.js
+++ b/test/ipld-eth.js
@@ -11,9 +11,10 @@ const ipldEthBlock = require('ipld-ethereum').ethBlock
 const ipldEthStateTrie = require('ipld-ethereum').ethStateTrie
 const loadFixture = require('aegir/fixtures')
 const async = require('async')
-const cidForHash = require('eth-hash-to-cid')
 const EthBlockHeader = require('ethereumjs-block/header')
 const EthTrieNode = require('merkle-patricia-tree/trieNode')
+const multihashes = require('multihashes')
+const CID = require('cids')
 
 const IPLDResolver = require('../src')
 
@@ -76,10 +77,12 @@ module.exports = (repo) => {
           default: throw new Error('Unknown type!')
         }
 
+        const multihash = multihashes.encode(node.hash(), 'keccak-256')
+        const cid = new CID(1, type, multihash)
         return {
           raw: rawData,
           node: node,
-          cid: cidForHash(type, node.hash())
+          cid: cid
         }
       }
 


### PR DESCRIPTION
The eth-hash-to-cid is a module that is no longer used by any
project. Hence replace it with two simple lines of code.