### PR TITLE
fix: "memdown" can be just a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eth-hash-to-cid": "~0.1.1",
     "ethereumjs-block": "^2.0.1",
     "lodash": "^4.17.11",
+    "memdown": "^3.0.0",
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2",
     "rlp": "^2.1.0"
@@ -60,7 +61,6 @@
     "is-ipfs": "~0.4.2",
     "lodash.flatten": "^4.4.0",
     "lodash.includes": "^4.3.0",
-    "memdown": "^3.0.0",
     "multihashes": "~0.4.14",
     "pull-defer": "~0.2.3",
     "pull-sort": "^1.0.1",


### PR DESCRIPTION
Untested, but from reading the code I can't see why it would be needed as a dependency. I remember that leveldb (leveldown) had this weird "peerDependency" on a leveldb implementation... if that's the case, feel free to dismiss this. Thanks!