### PR TITLE
chore: upgrade to ipld-dag-cbor 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ipfs-block-service": "~0.14.0",
     "ipfs-repo": "~0.24.0",
     "ipld-bitcoin": "~0.1.7",
-    "ipld-dag-cbor": "~0.12.1",
+    "ipld-dag-cbor": "~0.13.0",
     "ipld-dag-pb": "~0.14.10",
     "ipld-ethereum": "^2.0.1",
     "ipld-git": "~0.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -162,14 +162,15 @@ class IPLDResolver {
       },
       () => {
         const endReached = !path || path === '' || path === '/'
-        const isTerminal = value && !value['/']
+        const isTerminal = value && !IPLDResolver._maybeCID(value)
 
         if ((endReached && isTerminal) || options.localResolve) {
           return true
         } else {
+          value = IPLDResolver._maybeCID(value)
           // continue traversing
-          if (value && value['/']) {
-            cid = new CID(value['/'])
+          if (value) {
+            cid = value
           }
           return false
         }
@@ -308,7 +309,7 @@ class IPLDResolver {
               if (p.link) {
                 return {
                   basePath: base,
-                  cid: new CID(p.link['/'])
+                  cid: IPLDResolver._maybeCID(p.link)
                 }
               }
               return base
@@ -391,6 +392,25 @@ class IPLDResolver {
       }
       callback(null, cid)
     })
+  }
+
+  /**
+   * Return a CID instance if it is a link.
+   *
+   * If something is a link `{"/": "baseencodedcid"}` or a CID, then return
+   * a CID object, else return `null`.
+   *
+   * @param {*} link - The object to check
+   * @returns {?CID} - A CID instance
+   */
+  static _maybeCID (link) {
+    if (CID.isCID(link)) {
+      return link
+    }
+    if (link && link['/'] !== undefined) {
+      return new CID(link['/'])
+    }
+    return null
   }
 }
 

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -41,7 +41,7 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
         cidPb = cid
         nodeCbor = {
           someData: 'I am inside a Cbor object',
-          pb: { '/': cidPb.toBaseEncodedString() }
+          pb: cidPb
         }
 
         dagCBOR.util.cid(nodeCbor, cb)

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -43,7 +43,7 @@ module.exports = (repo) => {
         (cb) => {
           node2 = {
             someData: 'I am 2',
-            one: { '/': cid1.toBaseEncodedString() }
+            one: cid1
           }
 
           dagCBOR.util.cid(node2, (err, cid) => {
@@ -55,8 +55,8 @@ module.exports = (repo) => {
         (cb) => {
           node3 = {
             someData: 'I am 3',
-            one: { '/': cid1.toBaseEncodedString() },
-            two: { '/': cid2.toBaseEncodedString() }
+            one: cid1,
+            two: cid2
           }
 
           dagCBOR.util.cid(node3, (err, cid) => {


### PR DESCRIPTION
ipld-dag-cbor 0.13.0 contains a breaking change. The links are no
longer encoded as `{"/": "baseencodedcid"}` but are a CID instances.

As other formats still use the JSON notation of a link a helper
function is introduced to work with both.