### PR TITLE
refactor: make blockService an option parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Want to get started? Check our examples folder. You can check the development st
 - [Usage](#usage)
 - [API](#api)
   - IPLD Resolver
+    - [Constructor](#ipld-constructor)
     - [`.put(node, options, callback)`](#putnode-options-callback)
     - [`.get(cid [, path] [, options], callback)`](#getcid--path--options-callback)
     - [`.getStream(cid [, path] [, options])`](#getstreamcid--path--options)
@@ -78,7 +79,7 @@ const initIpld = (ipfsRepoPath, callback) => {
         return callback(err)
       }
       const blockService = new IpfsBlockService(repo)
-      const ipld = new Ipld(blockService)
+      const ipld = new Ipld({blockService: blockService})
       return callback(null, ipld)
     })
   })
@@ -90,6 +91,29 @@ initIpld('/tmp/ifpsrepo', (err, ipld) => {
 ```
 
 ## API
+
+### IPLD constructor
+
+> Creates and returns an instance of IPLD.
+
+```js
+const ipld = new Ipld(options)
+```
+
+The `options` is an object with any of these properties:
+
+##### `options.blockService`
+
+| Type | Default |
+|------|---------|
+| [`ipfs.BlockService`](https://github.com/ipfs/js-ipfs-block-service) instance | Required (no default) |
+
+Example:
+
+```js
+const blockService = new IpfsBlockService(repo)
+const ipld = new Ipld({blockService: blockService})
+```
 
 ### `.put(node, options, callback)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,12 @@ const MemoryStore = require('interface-datastore').MemoryDatastore
 function noop () {}
 
 class IPLDResolver {
-  constructor (blockService) {
-    if (!blockService) {
+  constructor (options) {
+    if (!options.blockService) {
       throw new Error('Missing blockservice')
     }
 
-    this.bs = blockService
+    this.bs = options.blockService
 
     // Support by default dag-pb, dag-cbor, git, and eth-*
     this.resolvers = {
@@ -439,7 +439,7 @@ IPLDResolver.inMemory = function (callback) {
     if (err) {
       return callback(err)
     }
-    callback(null, new IPLDResolver(blockService))
+    callback(null, new IPLDResolver({blockService}))
   })
 }
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -16,7 +16,7 @@ module.exports = (repo) => {
   describe('basics', () => {
     it('creates an instance', () => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       expect(r.bs).to.exist()
     })
 
@@ -34,7 +34,7 @@ module.exports = (repo) => {
   describe('validation', () => {
     it('get - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r.get(cid, '/', {}, (err, result) => {
@@ -46,7 +46,7 @@ module.exports = (repo) => {
 
     it('_get - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r.get(cid, (err, result) => {
@@ -58,7 +58,7 @@ module.exports = (repo) => {
 
     it('put - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       // choosing a format that is not supported
       r.put(null, { format: 'base1' }, (err, result) => {
         expect(err).to.exist()
@@ -69,7 +69,7 @@ module.exports = (repo) => {
 
     it('put - errors if no options', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       r.put(null, (err, result) => {
         expect(err).to.exist()
         expect(err.message).to.eql('IPLDResolver.put requires options')
@@ -79,7 +79,7 @@ module.exports = (repo) => {
 
     it('_put - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r._put(cid, null, (err, result) => {
@@ -91,7 +91,7 @@ module.exports = (repo) => {
 
     it('treeStream - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver(bs)
+      const r = new IPLDResolver({blockService: bs})
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       pull(

--- a/test/ipld-bitcoin.js
+++ b/test/ipld-bitcoin.js
@@ -39,7 +39,7 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -28,7 +28,7 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -26,7 +26,7 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {

--- a/test/ipld-eth-block.js
+++ b/test/ipld-eth-block.js
@@ -28,7 +28,7 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {

--- a/test/ipld-eth.js
+++ b/test/ipld-eth.js
@@ -24,7 +24,7 @@ module.exports = (repo) => {
     before(function (done) {
       this.timeout(10 * 1000)
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       async.waterfall([
         readFilesFixture,

--- a/test/ipld-git.js
+++ b/test/ipld-git.js
@@ -33,7 +33,7 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {

--- a/test/ipld-zcash.js
+++ b/test/ipld-zcash.js
@@ -44,7 +44,7 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver(bs)
+      resolver = new IPLDResolver({blockService: bs})
 
       series([
         (cb) => {


### PR DESCRIPTION
BREAKING CHANGE:

The IPLD constructor is no longer taking a BlockService as its
only parameter, but an objects object with `blockService` as a
key.

You need to upgrade your code if you initialize IPLD.

Prior to this change:

```js
const ipld = new Ipld(blockService)
```

Now:

```js
const ipld = new Ipld({blockService: blockService})
```