### PR TITLE
refactor: pass in IPLD Formats into the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Want to get started? Check our examples folder. You can check the development st
     - [`.remove(cid, callback)`](#removecid-callback)
     - [`.support.add(multicodec, formatResolver, formatUtil)`](#supportaddmulticodec-formatresolver-formatutil)
     - [`.support.rm(multicodec)`](#supportrmmulticodec)
+    - [Properties](#properties)
+      - [`defaultOptions`](#defaultoptions)
 - [Packages](#packages)
 - [Contribute](#contribute)
 - [License](#license)
@@ -115,6 +117,23 @@ const blockService = new IpfsBlockService(repo)
 const ipld = new Ipld({blockService: blockService})
 ```
 
+##### `options.formats`
+
+| Type | Default |
+|------|---------|
+| Array of [IPLD Format](https://github.com/ipld/interface-ipld-format) implementations | `[require('ipld-dag-cbor'), require('ipld-dag-pb'), require('ipld-raw')]` |
+
+By default only the [dag-cbor](https://github.com/ipld/js-ipld-dag-cbor)), [dag-pb](https://github.com/ipld/js-ipld-dag-pb)) and [raw](https://github.com/ipld/js-ipld-raw)) IPLD Formats are supported. Other formats need to be added manually. Here is an example if you want to have support for [ipld-git](https://github.com/ipld/js-ipld-git) only:
+
+```js
+const ipldGit = require('ipld-git')
+
+const ipld = new Ipld({
+  formats: [ipldGit],
+  …
+})
+```
+
 ### `.put(node, options, callback)`
 
 > Store the given node of a recognized IPLD Format.
@@ -160,6 +179,12 @@ const ipld = new Ipld({blockService: blockService})
 ### `.support.rm(multicodec)`
 
 > Removes support of an IPLD Format
+
+### Properties
+
+#### `defaultOptions`
+
+> Default options for IPLD.
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -34,14 +34,21 @@
   "license": "MIT",
   "devDependencies": {
     "aegir": "^15.2.0",
+    "bitcoinjs-lib": "^4.0.2",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "eth-hash-to-cid": "~0.1.1",
     "ethereumjs-block": "^2.0.1",
+    "ipld-bitcoin": "~0.1.7",
+    "ipld-ethereum": "^2.0.1",
+    "ipld-git": "~0.2.1",
+    "ipld-zcash": "~0.1.6",
+    "merkle-patricia-tree": "^2.3.2",
     "multihashes": "~0.4.14",
     "ncp": "^2.0.0",
     "rimraf": "^2.6.2",
-    "rlp": "^2.1.0"
+    "rlp": "^2.1.0",
+    "zcash-bitcore-lib": "~0.13.20-rc3"
   },
   "dependencies": {
     "async": "^2.6.1",
@@ -50,13 +57,10 @@
     "ipfs-block": "~0.7.1",
     "ipfs-block-service": "~0.14.0",
     "ipfs-repo": "~0.24.0",
-    "ipld-bitcoin": "~0.1.7",
     "ipld-dag-cbor": "~0.13.0",
     "ipld-dag-pb": "~0.14.10",
-    "ipld-ethereum": "^2.0.1",
-    "ipld-git": "~0.2.1",
     "ipld-raw": "^2.0.1",
-    "ipld-zcash": "~0.1.6",
+    "merge-options": "^1.0.1",
     "pull-defer": "~0.2.3",
     "pull-stream": "^3.6.9",
     "pull-traverse": "^1.0.3"

--- a/test/ipld-bitcoin.js
+++ b/test/ipld-bitcoin.js
@@ -39,7 +39,10 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({
+        blockService: bs,
+        formats: [ipldBitcoin]
+      })
 
       series([
         (cb) => {

--- a/test/ipld-eth-block.js
+++ b/test/ipld-eth-block.js
@@ -28,7 +28,10 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({
+        blockService: bs,
+        formats: [ipldEthBlock]
+      })
 
       series([
         (cb) => {

--- a/test/ipld-eth.js
+++ b/test/ipld-eth.js
@@ -7,6 +7,8 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const rlp = require('rlp')
 const BlockService = require('ipfs-block-service')
+const ipldEthBlock = require('ipld-ethereum').ethBlock
+const ipldEthStateTrie = require('ipld-ethereum').ethStateTrie
 const loadFixture = require('aegir/fixtures')
 const async = require('async')
 const cidForHash = require('eth-hash-to-cid')
@@ -24,7 +26,10 @@ module.exports = (repo) => {
     before(function (done) {
       this.timeout(10 * 1000)
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({
+        blockService: bs,
+        formats: [ipldEthBlock, ipldEthStateTrie]
+      })
 
       async.waterfall([
         readFilesFixture,

--- a/test/ipld-git.js
+++ b/test/ipld-git.js
@@ -33,7 +33,10 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({
+        blockService: bs,
+        formats: [ipldGit]
+      })
 
       series([
         (cb) => {

--- a/test/ipld-zcash.js
+++ b/test/ipld-zcash.js
@@ -44,7 +44,10 @@ module.exports = (repo) => {
 
     before((done) => {
       const bs = new BlockService(repo)
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({
+        blockService: bs,
+        formats: [ipldZcash]
+      })
 
       series([
         (cb) => {


### PR DESCRIPTION
Instead of having IPLD using all currently available [IPLD Format]
implementations automatically, pass the Formats that should be
used into the constructor as options.

This will also decrease the bundle size as every user of IPLD can
decide which IPLD Formats should be used. By default
[ipld-dag-cbor] and [ipld-dag-pb] are used as those are the ones
also heavily used within the IPFS ecosystem.

BREAKING CHANGE: Not all IPLD Formats are included by default

By default only the [ipld-dag-cbor] and [ipld-dag-pb] [IPLD Format]s
are included. If you want to use other IPLD Formats you need
to pass them into the constructor.

The code to restore the old behaviour could look like this:

```js
const ipldDagPb = require('ipld-dag-pb')
const ipldDagCbor = require('ipld-dag-cbor')
const ipldGit = require('ipld-git')
const ipldBitcoin = require('ipld-bitcoin')
const ipldEthAccountSnapshot = require('ipld-ethereum').ethAccountSnapshot
const ipldEthBlock = require('ipld-ethereum').ethBlock
const ipldEthBlockList = require('ipld-ethereum').ethBlockList
const ipldEthStateTrie = require('ipld-ethereum').ethStateTrie
const ipldEthStorageTrie = require('ipld-ethereum').ethStorageTrie
const ipldEthTx = require('ipld-ethereum').ethTx
const ipldEthtrie = require('ipld-ethereum').ethTxTrie
const ipldRaw = require('ipld-raw')
const ipldZcash = require('ipld-zcash')

…

const ipld = new Ipld({
  blockService: blockService,
  formats: [
    pldDagPb, ipldDagCbor, ipldGit, ipldBitcoin, ipldEthAccountSnapshot,
    ipldEthBlock, ipldEthBlockList, ipldEthStateTrie, ipldEthStorageTrie,
    ipldEthTx, ipldEthtrie, ipldRaw, ipldZcash
  ]
})
```

[ipld-dag-cbor]: https://github.com/ipld/js-ipld-dag-cbor
[ipld-dag-pb]: https://github.com/ipld/js-ipld-dag-pb
[IPLD Format]: https://github.com/ipld/interface-ipld-format

/cc @alanshaw @hugomrdias