### PR TITLE
feat: adds onlyHash option to ipld.put

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,12 @@ const ipld = new Ipld({
 
 `options` is an object that must contain one of the following combinations:
 - `cid` - the CID of the node
-- `[hashAlg]`, `[version]` and `format` - the hashAlg, version and the format that should be used to create the CID of the node. The 
+- `[hashAlg]`, `[version]` and `format` - the hashAlg, version and the format that should be used to create the CID of the node. The
 `hashAlg` and `version` defaults to the default values for the `format`.
+
+It may contain any of the following:
+
+- `onlyHash` - If true the serialized form of the node will not be passed to the underlying block store but the passed callback will be invoked as if it had been
 
 `callback` is a function that should have the signature as following: `function (err, cid) {}`, where `err` is an Error object in case of error and `cid` is the cid of the stored object.
 

--- a/src/index.js
+++ b/src/index.js
@@ -174,6 +174,10 @@ class IPLDResolver {
     callback = callback || noop
 
     if (options.cid && CID.isCID(options.cid)) {
+      if (options.onlyHash) {
+        return setImmediate(() => callback(null, options.cid))
+      }
+
       return this._put(options.cid, node, callback)
     }
 
@@ -184,6 +188,10 @@ class IPLDResolver {
     r.util.cid(node, options, (err, cid) => {
       if (err) {
         return callback(err)
+      }
+
+      if (options.onlyHash) {
+        return callback(null, cid)
       }
 
       this._put(cid, node, callback)

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -15,6 +15,7 @@ const dagPB = require('ipld-dag-pb')
 const dagCBOR = require('ipld-dag-cbor')
 const each = require('async/each')
 const waterfall = require('async/waterfall')
+const CID = require('cids')
 
 const IPLDResolver = require('../src')
 
@@ -63,6 +64,50 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
     resolver.get(cidCbor, 'pb/Data', (err, result) => {
       expect(err).to.not.exist()
       expect(result.value).to.eql(Buffer.from('I am inside a Protobuf'))
+      done()
+    })
+  })
+
+  it('does not store nodes when onlyHash is passed', (done) => {
+    waterfall([
+      (cb) => dagPB.DAGNode.create(Buffer.from('Some data here'), cb),
+      (node, cb) => resolver.put(nodePb, {
+        onlyHash: true,
+        version: 1,
+        hashAlg: 'sha2-256',
+        format: 'dag-pb'
+      }, cb),
+      (cid, cb) => resolver.bs._repo.blocks.has(cid, cb)
+    ], (error, result) => {
+      if (error) {
+        return done(error)
+      }
+
+      expect(result).to.be.false()
+      done()
+    })
+  })
+
+  it('does not store nodes when onlyHash is passed and a CID is passed', (done) => {
+    const cid = new CID('QmTmxQfEHbQzntsXPTU4ae2ZgBGwseBmS12AkZnKCkuf2G')
+
+    waterfall([
+      (cb) => dagPB.DAGNode.create(Buffer.from('Some data here'), cb),
+      (node, cb) => resolver.put(nodePb, {
+        onlyHash: true,
+        cid
+      }, cb),
+      (cid2, cb) => {
+        expect(cid2).to.equal(cid)
+
+        resolver.bs._repo.blocks.has(cid2, cb)
+      }
+    ], (error, result) => {
+      if (error) {
+        return done(error)
+      }
+
+      expect(result).to.be.false()
       done()
     })
   })


### PR DESCRIPTION
IPLD and it's resolvers are the gatekeepers of creating CIDs from nodes. IPFS has variations on `onlyHash` parameters that can be passed to CLI commands, the intention of which is to return a CID for a given node and not write it to a block store.

Since IPLD guards the block store and the generation of CIDs, we have to reach deep into it's heart to peform this. It makes sense that this should occur further down the stack so this PR adds an `onlyHash` option to `ipld.put` to accomplish this.