### PR TITLE
feat: dynamic format loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ const ipld = new Ipld({
 })
 ```
 
+##### `options.loadFormat(codec, callback)`
+
+| Type | Default |
+|------|---------|
+| `Function` | `null` |
+
+Function to dynamically load an [IPLD Format](https://github.com/ipld/interface-ipld-format). It is passed a string `codec`, the multicodec of the IPLD format to load and a callback function to call when the format has been loaded. e.g.
+
+```js
+const ipld = new Ipld({
+  loadFormat (codec, callback) {
+    if (codec === 'git-raw') {
+      callback(null, require('ipld-git'))
+    } else {
+      callback(new Error('unable to load format ' + codec))
+    }
+  }
+})
+```
+
 ### `.put(node, options, callback)`
 
 > Store the given node of a recognized IPLD Format.

--- a/test/browser.js
+++ b/test/browser.js
@@ -38,6 +38,7 @@ describe('Browser', () => {
   })
 
   require('./basics')(repo)
+  require('./format-support')(repo)
   require('./ipld-dag-pb')(repo)
   require('./ipld-dag-cbor')(repo)
   require('./ipld-git')(repo)

--- a/test/format-support.js
+++ b/test/format-support.js
@@ -78,6 +78,23 @@ module.exports = (repo) => {
           done()
         })
       })
+
+      it('should not dynamically load format added statically', (done) => {
+        const bs = new BlockService(repo)
+        const resolver = new IPLDResolver({
+          blockService: bs,
+          formats: [dagCBOR],
+          loadFormat (codec) {
+            throw new Error(`unexpected load format ${codec}`)
+          }
+        })
+
+        resolver.get(cid, '/', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value).to.eql(data)
+          done()
+        })
+      })
     })
   })
 }

--- a/test/format-support.js
+++ b/test/format-support.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+const BlockService = require('ipfs-block-service')
+const dagCBOR = require('ipld-dag-cbor')
+
+const IPLDResolver = require('../src')
+
+module.exports = (repo) => {
+  describe('IPLD format support', () => {
+    let data, cid
+
+    before((done) => {
+      const bs = new BlockService(repo)
+      const resolver = new IPLDResolver({ blockService: bs })
+
+      data = { now: Date.now() }
+
+      dagCBOR.util.cid(data, (err, c) => {
+        expect(err).to.not.exist()
+        cid = c
+        resolver.put(data, { cid }, done)
+      })
+    })
+
+    describe('Dynamic format loading', () => {
+      it('should fail to dynamically load format', (done) => {
+        const bs = new BlockService(repo)
+        const resolver = new IPLDResolver({
+          blockService: bs,
+          formats: []
+        })
+
+        resolver.get(cid, '/', (err) => {
+          expect(err).to.exist()
+          expect(err.message).to.equal('No resolver found for codec "dag-cbor"')
+          done()
+        })
+      })
+
+      it('should fail to dynamically load format via loadFormat option', (done) => {
+        const errMsg = 'BOOM' + Date.now()
+        const bs = new BlockService(repo)
+        const resolver = new IPLDResolver({
+          blockService: bs,
+          formats: [],
+          loadFormat (codec, callback) {
+            if (codec !== 'dag-cbor') return callback(new Error('unexpected codec'))
+            setTimeout(() => callback(new Error(errMsg)))
+          }
+        })
+
+        resolver.get(cid, '/', (err) => {
+          expect(err).to.exist()
+          expect(err.message).to.equal(errMsg)
+          done()
+        })
+      })
+
+      it('should dynamically load missing format', (done) => {
+        const bs = new BlockService(repo)
+        const resolver = new IPLDResolver({
+          blockService: bs,
+          formats: [],
+          loadFormat (codec, callback) {
+            if (codec !== 'dag-cbor') return callback(new Error('unexpected codec'))
+            setTimeout(() => callback(null, dagCBOR))
+          }
+        })
+
+        resolver.get(cid, '/', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.value).to.eql(data)
+          done()
+        })
+      })
+    })
+  })
+}

--- a/test/node.js
+++ b/test/node.js
@@ -27,6 +27,7 @@ describe('Node.js', () => {
   })
 
   require('./basics')(repo)
+  require('./format-support')(repo)
   require('./ipld-dag-pb')(repo)
   require('./ipld-dag-cbor')(repo)
   require('./ipld-git')(repo)


### PR DESCRIPTION
This backwards compatible PR allows missing IPLD formats to be loaded dynamically.

This follows on from the discussion here https://github.com/ipld/js-ipld/pull/164#discussion_r228121092

A new constructor option `loadFormat` allows users to asynchronously load an IPLD format. The IPLD instance will call this function automatically when it is requested to resolve a format that it doesn't currently understand.

This can re-enable lazy loading for IPLD modules in IPFS and also means that people who just want to add _more_ resolvers can do so without having to depend directly on the defaults and pass them in as well.

It also removes a bunch of repeated "No resolver found for codec" blocks so the code is more DRYFTW \o/