### PR TITLE
fix: updates ipld-dag-pb dep to version without .cid or .multihash properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ipfs-block-service": "~0.15.0",
     "ipfs-repo": "~0.25.0",
     "ipld-dag-cbor": "~0.13.0",
-    "ipld-dag-pb": "~0.14.11",
+    "ipld-dag-pb": "~0.15.0",
     "ipld-raw": "^2.0.1",
     "merge-options": "^1.0.1",
     "pull-defer": "~0.2.3",

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -51,36 +51,48 @@ module.exports = (repo) => {
           })
         },
         (cb) => {
-          dagPB.DAGNode.addLink(node2, {
-            name: '1',
-            size: node1.size,
-            multihash: node1.multihash
-          }, (err, node) => {
+          dagPB.util.cid(node1, (err, cid) => {
             expect(err).to.not.exist()
-            node2 = node
-            cb()
+
+            dagPB.DAGNode.addLink(node2, {
+              name: '1',
+              size: node1.size,
+              cid
+            }, (err, node) => {
+              expect(err).to.not.exist()
+              node2 = node
+              cb()
+            })
           })
         },
         (cb) => {
-          dagPB.DAGNode.addLink(node3, {
-            name: '1',
-            size: node1.size,
-            multihash: node1.multihash
-          }, (err, node) => {
+          dagPB.util.cid(node1, (err, cid) => {
             expect(err).to.not.exist()
-            node3 = node
-            cb()
+
+            dagPB.DAGNode.addLink(node3, {
+              name: '1',
+              size: node1.size,
+              cid
+            }, (err, node) => {
+              expect(err).to.not.exist()
+              node3 = node
+              cb()
+            })
           })
         },
         (cb) => {
-          dagPB.DAGNode.addLink(node3, {
-            name: '2',
-            size: node2.size,
-            multihash: node2.multihash
-          }, (err, node) => {
+          dagPB.util.cid(node2, (err, cid) => {
             expect(err).to.not.exist()
-            node3 = node
-            cb()
+
+            dagPB.DAGNode.addLink(node3, {
+              name: '2',
+              size: node2.size,
+              cid
+            }, (err, node) => {
+              expect(err).to.not.exist()
+              node3 = node
+              cb()
+            })
           })
         }
       ], cids)


### PR DESCRIPTION
**BREAKING CHANGE:**
DAGNodes no longer have `.cid` or `.multihash` properties - see ipld/js-ipld-dag-pb#99 for more and and https://github.com/ipld/js-ipld/issues/173 for the performance win.

Follows on from ipld/js-ipld-dag-pb#99 and updates this module to not rely on DAGNodes having knowledge of their CIDs.

Fixes the tests which could use a closer look at, for example they overwrite the value of `node3` twice.