### PR TITLE
perf: avoid double serialization

### DIFF
--- a/test/ipld-bitcoin.js
+++ b/test/ipld-bitcoin.js
@@ -10,7 +10,6 @@ const ipldBitcoin = require('ipld-bitcoin')
 const BitcoinBlock = require('bitcoinjs-lib').Block
 const multihash = require('multihashes')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 
 const IPLDResolver = require('../src')
@@ -97,16 +96,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: node1, cid: cid1 },
-          { node: node2, cid: cid2 },
-          { node: node3, cid: cid3 }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -8,7 +8,6 @@ chai.use(dirtyChai)
 const BlockService = require('ipfs-block-service')
 const dagCBOR = require('ipld-dag-cbor')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 const multihash = require('multihashes')
 
@@ -81,16 +80,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: node1, cid: cid1 },
-          { node: node2, cid: cid2 },
-          { node: node3, cid: cid3 }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -8,7 +8,6 @@ chai.use(dirtyChai)
 const BlockService = require('ipfs-block-service')
 const dagPB = require('ipld-dag-pb')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 const multihash = require('multihashes')
 const IPLDResolver = require('../src')
@@ -125,16 +124,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: node1, cid: cid1 },
-          { node: node2, cid: cid2 },
-          { node: node3, cid: cid3 }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-eth-block.js
+++ b/test/ipld-eth-block.js
@@ -10,7 +10,6 @@ const ipldEthBlock = require('ipld-ethereum').ethBlock
 const EthBlockHeader = require('ethereumjs-block/header')
 const multihash = require('multihashes')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 
 const IPLDResolver = require('../src')
@@ -85,16 +84,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: node1, cid: cid1 },
-          { node: node2, cid: cid2 },
-          { node: node3, cid: cid3 }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-git.js
+++ b/test/ipld-git.js
@@ -9,7 +9,6 @@ const BlockService = require('ipfs-block-service')
 const ipldGit = require('ipld-git')
 const multihash = require('multihashes')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 
 const IPLDResolver = require('../src')
@@ -150,18 +149,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: blobNode, cid: blobCid },
-          { node: treeNode, cid: treeCid },
-          { node: commitNode, cid: commitCid },
-          { node: commit2Node, cid: commit2Cid },
-          { node: tagNode, cid: tagCid }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(blobNode, { cid: blobCid }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-zcash.js
+++ b/test/ipld-zcash.js
@@ -10,7 +10,6 @@ const ipldZcash = require('ipld-zcash')
 const ZcashBlockHeader = require('zcash-bitcore-lib').BlockHeader
 const multihash = require('multihashes')
 const series = require('async/series')
-const each = require('async/each')
 const pull = require('pull-stream')
 
 const IPLDResolver = require('../src')
@@ -102,16 +101,6 @@ module.exports = (repo) => {
     })
 
     describe('internals', () => {
-      it('resolver._put', (done) => {
-        each([
-          { node: node1, cid: cid1 },
-          { node: node2, cid: cid2 },
-          { node: node3, cid: cid3 }
-        ], (nc, cb) => {
-          resolver._put(nc.cid, nc.node, cb)
-        }, done)
-      })
-
       it('resolver._get', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()


### PR DESCRIPTION
If you do not pass a `CID` instance to `ipld.put` right now it does the following:

1. get the `format` of a node from the passed `options.format`
2. get the `CID` of a node using `format.util.cid`
3. get the serialized form using `format.util.serialize`
4. write the serialized form into the blockstore using the `CID`

The way these formats typically calculate the `CID` of a node is by serializing it first, so during the above operations a node is serialized twice.

According to the [spec](https://github.com/ipld/interface-ipld-format#utilcidbinaryblob-options-callback) each format's `format.util.cid` method  should accept a binary blob as an argument (I read that as a `Buffer`).

This PR changes the order above to serialize first, then pass the serialized form to the relevant format implementation as per the spec.

It seems the only format implementation that accepts a binary blob is `dag-pb` so some extra work will need to be done to the other formats before it can be merged.