### PR TITLE
feat: return cid of last node traversed from ipld.get and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ It may contain any of the following:
 
 - `value` - the value that resulted from the get
 - `remainderPath` - If it didn't manage to successfully resolve the whole path through or if simply the `localResolve` option was passed.
+- `cid` - the last CID to be resolved during the traversal
 
 ### `.getMany(cids, callback)`
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ It may contain any of the following:
 
 - `value` - the value that resulted from the get
 - `remainderPath` - If it didn't manage to successfully resolve the whole path through or if simply the `localResolve` option was passed.
-- `cid` - If remainderPath has a value, this will be where it has it's root, otherwise it is the CID that was passed to `.get`
+- `cid` - Where the graph traversal finished - if `remainderPath` has a value, this will be where it has its root
 
 ### `.getMany(cids, callback)`
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ It may contain any of the following:
 
 - `value` - the value that resulted from the get
 - `remainderPath` - If it didn't manage to successfully resolve the whole path through or if simply the `localResolve` option was passed.
-- `cid` - the last CID to be resolved during the traversal
+- `cid` - If remainderPath has a value, this will be where it has it's root, otherwise it is the CID that was passed to `.get`
 
 ### `.getMany(cids, callback)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,8 @@ class IPLDResolver {
         }
         callback(null, {
           value: node,
-          remainderPath: ''
+          remainderPath: '',
+          cid
         })
       })
     }
@@ -145,7 +146,8 @@ class IPLDResolver {
         }
         return callback(null, {
           value: value,
-          remainderPath: path
+          remainderPath: path,
+          cid
         })
       }
     )

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ class IPLDResolver {
             if (err) {
               return cb(err)
             }
+
             format.resolver.resolve(block.data, path, (err, result) => {
               if (err) {
                 return cb(err)
@@ -130,6 +131,8 @@ class IPLDResolver {
         const isTerminal = value && !IPLDResolver._maybeCID(value)
 
         if ((endReached && isTerminal) || options.localResolve) {
+          cid = IPLDResolver._maybeCID(value) || cid
+
           return true
         } else {
           value = IPLDResolver._maybeCID(value)

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -245,6 +245,7 @@ module.exports = (repo) => {
           expect(err).to.not.exist()
           expect(result.value).to.eql('I am 1')
           expect(result.remainderPath).to.eql('')
+          expect(result.cid).to.deep.eql(cid1)
 
           done()
         })

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -253,6 +253,14 @@ module.exports = (repo) => {
         })
       })
 
+      it('resolver.get value within nested scope (1 level) returns cid of node traversed to', (done) => {
+        resolver.get(cid2, 'Links/0/Hash/Data', (err, result) => {
+          expect(err).to.not.exist()
+          expect(result.cid).to.deep.equal(cid1)
+          done()
+        })
+      })
+
       it('resolver.remove', (done) => {
         resolver.put(node1, { cid: cid1 }, (err) => {
           expect(err).to.not.exist()

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -249,6 +249,7 @@ module.exports = (repo) => {
           expect(result.value).to.eql({
             '/': 'QmS149H7EbyMuZ2wtEF1sAd7gPwjj4rKAorweAjKMkxr8D'
           })
+          expect(result.cid).to.deep.equal(cid2)
           done()
         })
       })


### PR DESCRIPTION
We can pass a path to `ipld.get` that makes the resolver attempt to do a graph traversal until it runs out of path segments to resolve.

At that point we don't know the `cid` of the node that will be returned, which things like the `unixfs-exporter` need to know.