### PR TITLE
fix: linting passes again

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/ipld/js-ipld#readme",
   "license": "MIT",
   "devDependencies": {
-    "aegir": "^17.0.0",
+    "aegir": "^17.1.1",
     "bitcoinjs-lib": "^4.0.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ class IPLDResolver {
 
     // Enable all supplied formats
     for (const format of options.formats) {
-      const {resolver, util} = format
+      const { resolver, util } = format
       const multicodec = resolver.multicodec
       this.support.add(multicodec, resolver, util)
     }
@@ -294,7 +294,7 @@ class IPLDResolver {
                   if (err) {
                     return cb(err)
                   }
-                  cb(null, {path: p, link: link})
+                  cb(null, { path: p, link: link })
                 })
               }, cb)
             })
@@ -450,7 +450,7 @@ IPLDResolver.inMemory = function (callback) {
     if (err) {
       return callback(err)
     }
-    callback(null, new IPLDResolver({blockService}))
+    callback(null, new IPLDResolver({ blockService }))
   })
 }
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -16,7 +16,7 @@ module.exports = (repo) => {
   describe('basics', () => {
     it('creates an instance', () => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       expect(r.bs).to.exist()
     })
 
@@ -34,7 +34,7 @@ module.exports = (repo) => {
   describe('validation', () => {
     it('get - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r.get(cid, '/', {}, (err, result) => {
@@ -46,7 +46,7 @@ module.exports = (repo) => {
 
     it('_get - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r.get(cid, (err, result) => {
@@ -58,7 +58,7 @@ module.exports = (repo) => {
 
     it('put - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       // choosing a format that is not supported
       r.put(null, { format: 'base1' }, (err, result) => {
         expect(err).to.exist()
@@ -69,7 +69,7 @@ module.exports = (repo) => {
 
     it('put - errors if no options', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       r.put(null, (err, result) => {
         expect(err).to.exist()
         expect(err.message).to.eql('IPLDResolver.put requires options')
@@ -79,7 +79,7 @@ module.exports = (repo) => {
 
     it('_put - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       r._put(cid, null, (err, result) => {
@@ -91,7 +91,7 @@ module.exports = (repo) => {
 
     it('treeStream - errors on unknown resolver', (done) => {
       const bs = new BlockService(repo)
-      const r = new IPLDResolver({blockService: bs})
+      const r = new IPLDResolver({ blockService: bs })
       // choosing a format that is not supported
       const cid = new CID(1, 'base1', multihash.encode(Buffer.from('abcd', 'hex'), 'sha1'))
       pull(

--- a/test/ipld-dag-cbor.js
+++ b/test/ipld-dag-cbor.js
@@ -28,7 +28,7 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({ blockService: bs })
 
       series([
         (cb) => {

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -26,7 +26,7 @@ module.exports = (repo) => {
     before((done) => {
       const bs = new BlockService(repo)
 
-      resolver = new IPLDResolver({blockService: bs})
+      resolver = new IPLDResolver({ blockService: bs })
 
       series([
         (cb) => {

--- a/test/ipld-git.js
+++ b/test/ipld-git.js
@@ -51,7 +51,7 @@ module.exports = (repo) => {
         (cb) => {
           treeNode = {
             somefile: {
-              hash: {'/': blobCid.buffer},
+              hash: { '/': blobCid.buffer },
               mode: '100644'
             }
           }
@@ -65,7 +65,7 @@ module.exports = (repo) => {
         (cb) => {
           commitNode = {
             gitType: 'commit',
-            tree: {'/': treeCid.buffer},
+            tree: { '/': treeCid.buffer },
             parents: [],
             author: {
               name: 'John Doe',
@@ -89,9 +89,9 @@ module.exports = (repo) => {
         (cb) => {
           commit2Node = {
             gitType: 'commit',
-            tree: {'/': treeCid.buffer},
+            tree: { '/': treeCid.buffer },
             parents: [
-              {'/': commitCid.buffer}
+              { '/': commitCid.buffer }
             ],
             author: {
               name: 'John Doe',
@@ -115,7 +115,7 @@ module.exports = (repo) => {
         (cb) => {
           tagNode = {
             gitType: 'tag',
-            object: {'/': commit2Cid.buffer},
+            object: { '/': commit2Cid.buffer },
             type: 'commit',
             tag: 'v0.0.0',
             tagger: {


### PR DESCRIPTION
With the AEgir 17.1.1 release StandardJS 12 was introduced, which lead
to new linting rules. Those rules made the linting fail. This commit
fixes those issues and also upgrades AEgir to 17.1.1 explicitly.