### PR TITLE
refactor: remove inMemory util

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ipld-bitcoin": "~0.1.8",
     "ipld-ethereum": "^2.0.1",
     "ipld-git": "~0.2.2",
+    "ipld-in-memory": "^2.0.0",
     "ipld-zcash": "~0.1.6",
     "merkle-patricia-tree": "^2.3.2",
     "multihashes": "~0.4.14",
@@ -52,10 +53,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "cids": "~0.5.5",
-    "interface-datastore": "~0.6.0",
     "ipfs-block": "~0.8.0",
-    "ipfs-block-service": "~0.15.0",
-    "ipfs-repo": "~0.26.0",
     "ipld-dag-cbor": "~0.13.0",
     "ipld-dag-pb": "~0.15.2",
     "ipld-raw": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,12 @@ const Block = require('ipfs-block')
 const pull = require('pull-stream')
 const CID = require('cids')
 const doUntil = require('async/doUntil')
-const IPFSRepo = require('ipfs-repo')
-const BlockService = require('ipfs-block-service')
 const joinPath = require('path').join
 const osPathSep = require('path').sep
 const pullDeferSource = require('pull-defer').source
 const pullTraverse = require('pull-traverse')
 const map = require('async/map')
-const series = require('async/series')
 const waterfall = require('async/waterfall')
-const MemoryStore = require('interface-datastore').MemoryDatastore
 const mergeOptions = require('merge-options')
 const ipldDagCbor = require('ipld-dag-cbor')
 const ipldDagPb = require('ipld-dag-pb')
@@ -423,35 +419,6 @@ class IPLDResolver {
  */
 IPLDResolver.defaultOptions = {
   formats: [ipldDagCbor, ipldDagPb, ipldRaw]
-}
-
-/**
- * Create an IPLD resolver with an in memory blockservice and
- * repo.
- *
- * @param {function(Error, IPLDResolver)} callback
- * @returns {void}
- */
-IPLDResolver.inMemory = function (callback) {
-  const repo = new IPFSRepo('in-memory', {
-    storageBackends: {
-      root: MemoryStore,
-      blocks: MemoryStore,
-      datastore: MemoryStore
-    },
-    lock: 'memory'
-  })
-  const blockService = new BlockService(repo)
-
-  series([
-    (cb) => repo.init({}, cb),
-    (cb) => repo.open(cb)
-  ], (err) => {
-    if (err) {
-      return callback(err)
-    }
-    callback(null, new IPLDResolver({ blockService }))
-  })
 }
 
 module.exports = IPLDResolver

--- a/test/basics.js
+++ b/test/basics.js
@@ -9,6 +9,7 @@ const BlockService = require('ipfs-block-service')
 const CID = require('cids')
 const multihash = require('multihashes')
 const pull = require('pull-stream')
+const inMemory = require('ipld-in-memory')
 
 const IPLDResolver = require('../src')
 
@@ -21,7 +22,7 @@ module.exports = (repo) => {
     })
 
     it('creates an in memory repo if no blockService is passed', () => {
-      IPLDResolver.inMemory((err, r) => {
+      inMemory(IPLDResolver, (err, r) => {
         expect(err).to.not.exist()
         expect(r.bs).to.exist()
       })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -16,6 +16,7 @@ const dagCBOR = require('ipld-dag-cbor')
 const each = require('async/each')
 const waterfall = require('async/waterfall')
 const CID = require('cids')
+const inMemory = require('ipld-in-memory')
 
 const IPLDResolver = require('../src')
 
@@ -29,7 +30,7 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
 
   before((done) => {
     waterfall([
-      (cb) => IPLDResolver.inMemory(cb),
+      (cb) => inMemory(IPLDResolver, cb),
       (res, cb) => {
         resolver = res
         dagPB.DAGNode.create(Buffer.from('I am inside a Protobuf'), cb)


### PR DESCRIPTION
This removes the dependency on `ipfs-repo`, `ipfs-block-service` and `interface-datastore` and resolves #151.

BTW the current implementation has a bug where the `keys` backend is stored on disk and not in memory. I [added it here](https://github.com/alanshaw/ipld-in-memory/blob/01b86380ebec95248d090a5a0ae95141bcc4067c/index.js#L18), compare with [the current backends](https://github.com/ipld/js-ipld/blob/f7494ec7b7a52a34d33d8ec308718b31919e08b6/src/index.js#L438-L440)...so definitely worth switching ;)

BREAKING CHANGE: This module no longer exports an `inMemory` utility to create an IPLD instance that uses a block service that stores data in memory. Please use the [`ipld-in-memory`](https://www.npmjs.com/package/ipld-in-memory) module instead.