### PR TITLE
fix: respect the `cidVersion` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ class IPLDResolver {
     const options = mergeOptions(defaultOptions, userOptions)
 
     const cidOptions = {
-      version: options.cidVersion,
+      cidVersion: options.cidVersion,
       hashAlg: options.hashAlg,
       onlyHash: options.onlyHash
     }

--- a/test/ipld-dag-pb.js
+++ b/test/ipld-dag-pb.js
@@ -135,6 +135,24 @@ module.exports = (repo) => {
           await expect(resolver.get(cid)).to.eventually.be.rejected()
         }
       })
+
+      it('should return a v0 CID when specified', async () => {
+        const node = dagPB.DAGNode.create(Buffer.from('a dag-pb node'))
+        const cid = await resolver.put(node, multicodec.DAG_PB, {
+          cidVersion: 0
+        })
+
+        expect(cid.version).to.equal(0)
+      })
+
+      it('should return a v1 CID when specified', async () => {
+        const node = dagPB.DAGNode.create(Buffer.from('a dag-pb node'))
+        const cid = await resolver.put(node, multicodec.DAG_PB, {
+          cidVersion: 1
+        })
+
+        expect(cid.version).to.equal(1)
+      })
     })
   })
 }


### PR DESCRIPTION
The [interface-ipld-format spec](https://github.com/ipld/interface-ipld-format#utilcidbinaryblob-options) says the CID verison option is `cidVersion`.  This module passes it to formats as `version` which is subsequently ignored.

Since `ipld-dag-pb` now defaults to V1 CIDs this results in incorrect CIDs being generated if you request V0 CIDs.