### PR TITLE
refactor: make code promisify free

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "dirty-chai": "^2.0.1",
     "ethereumjs-block": "^2.2.0",
     "fs-extra": "^8.0.1",
-    "ipfs-block-service": "~0.15.2",
-    "ipfs-repo": "~0.26.5",
+    "ipfs-block-service": "^0.16.0",
+    "ipfs-repo": "^0.27.0",
     "ipld-bitcoin": "~0.3.0",
     "ipld-ethereum": "^4.0.0",
     "ipld-git": "~0.5.0",
-    "ipld-in-memory": "^2.0.0",
+    "ipld-in-memory": "^3.0.0",
     "ipld-zcash": "~0.3.0",
     "merkle-patricia-tree": "^3.0.0",
     "multihashes": "~0.4.14",
@@ -60,7 +60,6 @@
     "ipld-raw": "^4.0.0",
     "merge-options": "^1.0.1",
     "multicodec": "~0.5.1",
-    "promisify-es6": "^1.0.3",
     "typical": "^5.0.0"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ const ipldDagCbor = require('ipld-dag-cbor')
 const ipldDagPb = require('ipld-dag-pb')
 const ipldRaw = require('ipld-raw')
 const multicodec = require('multicodec')
-const promisify = require('promisify-es6')
 const typical = require('typical')
 const { extendIterator } = require('./util')
 
@@ -95,7 +94,7 @@ class IPLDResolver {
         // get block
         // use local resolver
         // update path value
-        const block = await promisify(this.bs.get.bind(this.bs))(cid)
+        const block = await this.bs.get(cid)
         const result = format.resolver.resolve(block.data, path)
 
         // Prepare for the next iteration if there is a `remainderPath`
@@ -129,7 +128,7 @@ class IPLDResolver {
    * @returns {Promise.<Object>} - Returns a Promise with the IPLD Node that correspond to the given `cid`.
    */
   async get (cid) {
-    const block = await promisify(this.bs.get.bind(this.bs))(cid)
+    const block = await this.bs.get(cid)
     const format = await this._getFormat(block.cid.codec)
     const node = format.util.deserialize(block.data)
 
@@ -194,7 +193,7 @@ class IPLDResolver {
 
     if (!options.onlyHash) {
       const block = new Block(serialized, cid)
-      await promisify(this.bs.put.bind(this.bs))(block)
+      await this.bs.put(block)
     }
 
     return cid
@@ -255,7 +254,7 @@ class IPLDResolver {
    * @return {Promise.<CID>} The CID of the removed IPLD Node.
    */
   async remove (cid) { // eslint-disable-line require-await
-    return promisify(this.bs.delete.bind(this.bs))(cid)
+    return this.bs.delete(cid)
   }
 
   /**
@@ -336,7 +335,7 @@ class IPLDResolver {
         if (treePaths.length === 0 && queue.length > 0) {
           ({ cid, basePath } = queue.shift())
           const format = await this._getFormat(cid.codec)
-          block = await promisify(this.bs.get.bind(this.bs))(cid)
+          block = await this.bs.get(cid)
 
           const paths = format.resolver.tree(block.data)
           treePaths.push(...paths)

--- a/test/basics.js
+++ b/test/basics.js
@@ -23,8 +23,8 @@ module.exports = (repo) => {
       expect(r.bs).to.exist()
     })
 
-    it('creates an in memory repo if no blockService is passed', () => {
-      inMemory(IPLDResolver, (err, r) => {
+    it('creates an in memory repo if no blockService is passed', async () => {
+      await inMemory(IPLDResolver, (err, r) => {
         expect(err).to.not.exist()
         expect(r.bs).to.exist()
       })

--- a/test/browser.js
+++ b/test/browser.js
@@ -4,7 +4,6 @@
 'use strict'
 
 const IPFSRepo = require('ipfs-repo')
-const promisify = require('promisify-es6')
 
 const basePath = 'ipfs' + Math.random()
 
@@ -19,17 +18,13 @@ idb.deleteDatabase(basePath + '/blocks')
 describe('Browser', () => {
   const repo = new IPFSRepo(basePath)
 
-  const repoInit = promisify(repo.init.bind(repo))
-  const repoOpen = promisify(repo.open.bind(repo))
-  const repoClose = promisify(repo.close.bind(repo))
-
   before(async () => {
-    await repoInit({})
-    await repoOpen()
+    await repo.init({})
+    await repo.open()
   })
 
   after(async () => {
-    await repoClose()
+    await repo.close()
     idb.deleteDatabase(basePath)
     idb.deleteDatabase(basePath + '/blocks')
   })

--- a/test/ipld-all.js
+++ b/test/ipld-all.js
@@ -17,7 +17,6 @@ const dagPB = require('ipld-dag-pb')
 const CID = require('cids')
 const inMemory = require('ipld-in-memory')
 const multicodec = require('multicodec')
-const promisify = require('promisify-es6')
 
 const IPLDResolver = require('../src')
 
@@ -30,12 +29,7 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
   let cidPb
 
   before(async () => {
-    resolver = await new Promise((resolve, reject) => {
-      inMemory(IPLDResolver, (error, res) => {
-        if (error) reject(error)
-        else resolve(res)
-      })
-    })
+    resolver = await inMemory(IPLDResolver)
 
     nodePb = dagPB.DAGNode.create(Buffer.from('I am inside a Protobuf'))
     cidPb = await resolver.put(nodePb, multicodec.DAG_PB, { cidVersion: 0 })
@@ -65,7 +59,7 @@ describe('IPLD Resolver for dag-cbor + dag-pb', () => {
       cidVersion: 1,
       hashAlg: multicodec.SHA2_256
     })
-    const result = await promisify(resolver.bs._repo.blocks.has)(cid)
+    const result = await resolver.bs._repo.blocks.has(cid)
     expect(result).to.be.false()
   })
 

--- a/test/node.js
+++ b/test/node.js
@@ -3,7 +3,6 @@
 
 const fs = require('fs-extra')
 const IPFSRepo = require('ipfs-repo')
-const promisify = require('promisify-es6')
 const os = require('os')
 
 describe('Node.js', () => {
@@ -11,16 +10,13 @@ describe('Node.js', () => {
   const repoTests = os.tmpdir() + '/t-r-' + Date.now()
   const repo = new IPFSRepo(repoTests)
 
-  const repoOpen = promisify(repo.open.bind(repo))
-  const repoClose = promisify(repo.close.bind(repo))
-
   before(async () => {
     await fs.copy(repoExample, repoTests)
-    await repoOpen()
+    await repo.open()
   })
 
   after(async () => {
-    await repoClose()
+    await repo.close()
     await fs.remove(repoTests)
   })
 


### PR DESCRIPTION
There's no need for the promisify-es6 module anymore as all the code
is using async/await based libraries now.