### PR TITLE
fix: minor improvement to path handling in Node.js tests

### DIFF
--- a/test/node.js
+++ b/test/node.js
@@ -1,13 +1,14 @@
 /* eslint-env mocha */
 'use strict'
 
+const path = require('path')
 const fs = require('fs-extra')
 const IPFSRepo = require('ipfs-repo')
 const os = require('os')
 
 describe('Node.js', () => {
-  const repoExample = process.cwd() + '/test/example-repo'
-  const repoTests = os.tmpdir() + '/t-r-' + Date.now()
+  const repoExample = path.join(process.cwd(), 'test/example-repo')
+  const repoTests = fs.mkdtempSync(path.join(os.tmpdir(), 'js-ipld-'))
   const repo = new IPFSRepo(repoTests)
 
   before(async () => {


### PR DESCRIPTION
I'm pretty sure this has nothing to do with the flaky Windows tests but I noticed it while testing on Windows. String concatenation is a no-no for building cross-platform and safe paths, and there's a `fs.mkdtemp()` these days to do the work of making a safe temp dir.