### PR TITLE
fix: create buffers from decoded multihash digests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ethereumjs-block": "^2.2.0",
     "ipld-bitcoin": "^0.4.0",
     "ipld-ethereum": "^5.0.0",
-    "ipld-git": "^0.6.0",
+    "ipld-git": "^0.6.1",
     "ipld-in-memory": "^5.0.0",
     "ipld-zcash": "^0.5.0",
     "merkle-patricia-tree": "^3.0.0",

--- a/test/ipld-bitcoin.spec.js
+++ b/test/ipld-bitcoin.spec.js
@@ -14,8 +14,8 @@ const IPLDResolver = require('../src')
 const buildBitcoinBlock = (header) => {
   const block = new BitcoinBlock()
   block.version = header.version || 0
-  block.prevHash = header.prevHash || Buffer.alloc(32)
-  block.merkleRoot = header.merkleRoot || Buffer.alloc(32)
+  block.prevHash = header.prevHash ? Buffer.from(header.prevHash) : Buffer.alloc(32)
+  block.merkleRoot = header.merkleRoot ? Buffer.from(header.merkleRoot) : Buffer.alloc(32)
   block.timestamp = header.timestamp || 0
   block.bits = header.bits || 0
   block.nonce = header.nonce || 0


### PR DESCRIPTION
`multihash.decode` returns Uint8Arrays which we set as `prevHash`
but bitcoin-lib requires these to be node Buffers.