### PR TITLE
feat: expose getFormat function

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ the new strategy in [Issue #260](https://github.com/ipld/js-ipld/issues/260)
   - [`.removeMany(cids, options)`](#removemanycids-options)
   - [`.tree(cid, [path], [options])`](#treecid-path-options)
   - [`.addFormat(ipldFormatImplementation)`](#addformatipldformatimplementation)
+  - [`.getFormat(codec)`](#getformatcodec)
   - [`.removeFormat(codec)`](#removeformatcodec)
   - [Properties](#properties)
     - [`defaultOptions`](#defaultoptions)
@@ -284,6 +285,13 @@ Returns an async iterator of all the paths (as Strings) you could resolve into.
 
 Returns the IPLD instance. This way you can chain `addFormat()` calls.
 
+### `.getFormat(codec)`
+
+> Return the implementation for an IPLD Format
+
+- `codec` (`multicodec`, required): the codec of the IPLD Format to return the implementation from.
+
+If the implementation is not present in the current list of resolvers, the `loadFormat` function passed as an option to the constructor of this module will be invoked and it's output added to the list of available resolvers.
 
 ### `.removeFormat(codec)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ class IPLDResolver {
     const generator = async function * () {
       // End iteration if there isn't a CID to follow anymore
       while (cid !== null) {
-        const format = await this._getFormat(cid.codec)
+        const format = await this.getFormat(cid.codec)
 
         // get block
         // use local resolver
@@ -133,7 +133,7 @@ class IPLDResolver {
    */
   async get (cid, options) {
     const block = await this.bs.get(cid, options)
-    const format = await this._getFormat(block.cid.codec)
+    const format = await this.getFormat(block.cid.codec)
     const node = format.util.deserialize(block.data)
 
     return node
@@ -182,7 +182,7 @@ class IPLDResolver {
       throw new Error('`format` parameter must be number (multicodec)')
     }
 
-    const formatImpl = await this._getFormat(format)
+    const formatImpl = await this.getFormat(format)
     const defaultOptions = {
       hashAlg: formatImpl.defaultHashAlg,
       cidVersion: 1,
@@ -239,7 +239,7 @@ class IPLDResolver {
         // when we hit the first iteration. This way the constructor can be
         // a synchronous function.
         if (options === undefined) {
-          formatImpl = await this._getFormat(format)
+          formatImpl = await this.getFormat(format)
           const defaultOptions = {
             hashAlg: formatImpl.defaultHashAlg,
             cidVersion: 1,
@@ -318,7 +318,7 @@ class IPLDResolver {
     // If a path is a link then follow it and return its CID
     const maybeRecurse = async (block, treePath) => {
       // A treepath we might want to follow recursively
-      const format = await this._getFormat(block.cid.codec)
+      const format = await this.getFormat(block.cid.codec)
       const result = format.resolver.resolve(block.data, treePath)
       // Something to follow recusively, hence push it into the queue
       if (CID.isCID(result.value)) {
@@ -347,7 +347,7 @@ class IPLDResolver {
         // There aren't any paths left, get them from the given CID
         if (treePaths.length === 0 && queue.length > 0) {
           ({ cid, basePath } = queue.shift())
-          const format = await this._getFormat(cid.codec)
+          const format = await this.getFormat(cid.codec)
           block = await this.bs.get(cid, options)
 
           const paths = format.resolver.tree(block.data)
@@ -381,10 +381,7 @@ class IPLDResolver {
     return extendIterator(generator())
   }
 
-  /*           */
-  /* internals */
-  /*           */
-  async _getFormat (codec) {
+  async getFormat (codec) {
     // TODO vmx 2019-01-24: Once all CIDs support accessing the codec code
     // instead of the name, remove this part
     if (typeof codec === 'string') {


### PR DESCRIPTION
It's useful to be able to get the format implementations out of ipld
just before `ipld.put` operations in the HTTP API server of IPFS.

This is because we've serialized the node on the client for transmission
over HTTP so need to deserialize it before passing it into `ipld.put`
for it to be serialized (and as such, verified) again.

We can duplicate the list of resolvers and logic behind the addition
of new resolvers from ipld or we can just expose the `getFormat` function
which we do here to reduce any code duplication.