### PR TITLE
fix: use correct property when checking if resolver exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ class IPLDResolver {
    */
   addFormat (format) {
     const codec = format.codec
-    if (this.resolvers[format.format]) {
+
+    if (this.resolvers[format.codec]) {
       const codecName = multicodec.print[codec]
       throw new Error(`Resolver already exists for codec "${codecName}"`)
     }

--- a/test/format-support.spec.js
+++ b/test/format-support.spec.js
@@ -8,72 +8,80 @@ const inMemory = require('ipld-in-memory')
 
 const IPLDResolver = require('../src')
 
-module.exports = (repo) => {
-  describe('IPLD format support', () => {
-    let data, cid
+describe('IPLD format support', () => {
+  let data, cid
 
-    before(async () => {
-      const resolver = await inMemory(IPLDResolver)
+  before(async () => {
+    const resolver = await inMemory(IPLDResolver)
 
-      data = { now: Date.now() }
+    data = { now: Date.now() }
+
+    cid = await resolver.put(data, multicodec.DAG_CBOR)
+  })
+
+  describe('Dynamic format loading', () => {
+    it('should fail to dynamically load format', async () => {
+      const resolver = await inMemory(IPLDResolver, {
+        formats: []
+      })
+
+      const result = resolver.resolve(cid, '')
+      await expect(result.next()).to.be.rejectedWith(
+        'No resolver found for codec "dag-cbor"')
+    })
+
+    it('should fail to dynamically load format via loadFormat option', async () => {
+      const errMsg = 'BOOM' + Date.now()
+      const resolver = await inMemory(IPLDResolver, {
+        formats: [],
+        loadFormat (codec) {
+          if (codec !== multicodec.DAG_CBOR) {
+            throw new Error('unexpected codec')
+          }
+          throw new Error(errMsg)
+        }
+      })
+
+      const result = resolver.resolve(cid, '')
+      await expect(result.next()).to.be.rejectedWith(errMsg)
+    })
+
+    it('should dynamically load missing format', async () => {
+      const resolver = await inMemory(IPLDResolver, {
+        formats: [],
+        loadFormat (codec) {
+          if (codec !== multicodec.DAG_CBOR) {
+            throw new Error('unexpected codec')
+          }
+          return dagCBOR
+        }
+      })
 
       cid = await resolver.put(data, multicodec.DAG_CBOR)
+
+      await expect(resolver.get(cid)).to.eventually.eql(data)
     })
 
-    describe('Dynamic format loading', () => {
-      it('should fail to dynamically load format', async () => {
-        const resolver = await inMemory(IPLDResolver, {
-          formats: []
-        })
-
-        const result = resolver.resolve(cid, '')
-        await expect(result.next()).to.be.rejectedWith(
-          'No resolver found for codec "dag-cbor"')
+    it('should not dynamically load format added statically', async () => {
+      const resolver = await inMemory(IPLDResolver, {
+        formats: [dagCBOR],
+        loadFormat (codec) {
+          throw new Error(`unexpected load format ${codec}`)
+        }
       })
 
-      it('should fail to dynamically load format via loadFormat option', async () => {
-        const errMsg = 'BOOM' + Date.now()
-        const resolver = await inMemory(IPLDResolver, {
-          formats: [],
-          loadFormat (codec) {
-            if (codec !== multicodec.DAG_CBOR) {
-              throw new Error('unexpected codec')
-            }
-            throw new Error(errMsg)
-          }
-        })
+      cid = await resolver.put(data, multicodec.DAG_CBOR)
 
-        const result = resolver.resolve(cid, '')
-        await expect(result.next()).to.be.rejectedWith(errMsg)
+      await expect(resolver.get(cid)).to.eventually.eql(data)
+    })
+
+    it('should throw if adding format twice', async () => {
+      const resolver = await inMemory(IPLDResolver, {
+        formats: []
       })
+      resolver.addFormat(dagCBOR)
 
-      it('should dynamically load missing format', async () => {
-        const resolver = await inMemory(IPLDResolver, {
-          formats: [],
-          loadFormat (codec) {
-            if (codec !== multicodec.DAG_CBOR) {
-              throw new Error('unexpected codec')
-            }
-            return dagCBOR
-          }
-        })
-
-        const result = resolver.resolve(cid, '')
-        const node = await result.first()
-        expect(node.value).to.eql(data)
-      })
-
-      it('should not dynamically load format added statically', async () => {
-        const resolver = await inMemory(IPLDResolver, {
-          formats: [dagCBOR],
-          loadFormat (codec) {
-            throw new Error(`unexpected load format ${codec}`)
-          }
-        })
-
-        const result = resolver.resolve(cid, '')
-        await result.next()
-      })
+      expect(() => resolver.addFormat(dagCBOR)).to.throw(/Resolver already exists/)
     })
   })
-}
+})


### PR DESCRIPTION
The right property is `.codec` and not `.format`.

Adds a test for the same and also runs the custom format tests again.